### PR TITLE
Fix cli test case

### DIFF
--- a/paper/cli.py
+++ b/paper/cli.py
@@ -6,26 +6,22 @@ from paper.librarian import Librarian
 
 
 @click.group()
-def cmd():
+def main():
     pass
 
 
-@cmd.command()
+@main.command()
 @click.argument('keywords', nargs=-1)
 def search(keywords):
     librarian = Librarian()
     papers = librarian.search(keywords)
     for index, paper in enumerate(papers):
-        print(str(index) + '. ' + paper['title'], end='')
+        print(str(index) + '. ' + paper['title'])
         print(' (PDF is N/A)' if paper['url'] is None else '')
         print('   ' + ', '.join(paper['authors']))
     user_input = librarian.get_user_input(papers)
     librarian.save(papers[user_input])
     return 0
-
-
-def main():
-    cmd()
 
 
 if __name__ == "__main__":

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -5,30 +5,20 @@
 
 
 import unittest
-# from click.testing import CliRunner
+from click.testing import CliRunner
 
-# from paper import paper
-# from paper import cli
+from paper import cli
 
 
 class TestPaper(unittest.TestCase):
     """Tests for `paper` package."""
 
-    # def setUp(self):
-    #     """Set up test fixtures, if any."""
-
-    # def tearDown(self):
-    #     """Tear down test fixtures, if any."""
-
-    # def test_000_something(self):
-    #     """Test something."""
-
-    # def test_command_line_interface(self):
-    #     """Test the CLI."""
-    #     runner = CliRunner()
-    #     result = runner.invoke(cli.main)
-    #     assert result.exit_code == 0
-    #     assert 'paper.cli.main' in result.output
-    #     help_result = runner.invoke(cli.main, ['--help'])
-    #     assert help_result.exit_code == 0
-    #     assert '--help  Show this message and exit.' in help_result.output
+    def test_command_line_interface(self):
+        """Test the CLI."""
+        runner = CliRunner()
+        result = runner.invoke(cli.main)
+        assert result.exit_code == 0
+        assert 'main' in result.output
+        help_result = runner.invoke(cli.main, ['--help'])
+        assert help_result.exit_code == 0
+        assert '--help  Show this message and exit.' in help_result.output


### PR DESCRIPTION
I fixed test cases for cli reverting commented test cases. Please let me know when you have any problems.

```
 python3 setup.py test
running test
running egg_info
writing paper.egg-info/PKG-INFO
writing top-level names to paper.egg-info/top_level.txt
writing entry points to paper.egg-info/entry_points.txt
writing dependency_links to paper.egg-info/dependency_links.txt
writing requirements to paper.egg-info/requires.txt
reading manifest file 'paper.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no files found matching '*.jpg' under directory 'docs'
warning: no files found matching '*.png' under directory 'docs'
warning: no files found matching '*.gif' under directory 'docs'
writing manifest file 'paper.egg-info/SOURCES.txt'
running build_ext
test_command_line_interface (tests.test_paper.TestPaper)
Test the CLI. ... ok
test_extract_papers_from (tests.test_search.TestSearch) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.010s

OK
```